### PR TITLE
change ioctl-sys 's version to 0.8 in Cargo.toml

### DIFF
--- a/ioctls/Cargo.toml
+++ b/ioctls/Cargo.toml
@@ -10,4 +10,4 @@ include = ["Cargo.toml", "**/*.rs"]
 
 [dependencies]
 libc = "0.2"
-ioctl-sys = { path = "../ioctl-sys", version = ">=0.6, <0.8" }
+ioctl-sys = { path = "../ioctl-sys", version = ">=0.6, <=0.8" }


### PR DESCRIPTION
`ioctl-sys` support risc-v arch since v0.8.0, because of which it may be better to change ioctl-sys 's version constraints in ioctls 's toml.
Thanks!